### PR TITLE
Fix search#51

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'ransack'
 
 gem 'faker'
 
+gem 'enum_help'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -10,6 +10,7 @@ class Schedule < ApplicationRecord
   validates :sleep_time, presence: true
   validate :three_main_events_validate
 
+  enum assumed_number_people: [ :one_person, :two_people, :three_people, :four_or_more_people ]
   def three_main_events_validate
     three_main_events = 3
     main_event_count = 0

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -5,7 +5,7 @@
             <%=f.text_field :schedule_title, placeholder: "スケジュールタイトル", class: "input input-bordered border-accent w-full"%>
         </div>
         <div class="w-1/5">
-            <%=f.number_field :assumed_number_people, placeholder: "おすすめ人数", class: "mt-6 ml-2" %>
+            <%= f.select :assumed_number_people, Schedule.assumed_number_people.keys.map { |k| [t("enums.schedule.assumed_number_people.#{k}"), k] }, { include_blank: "指定なし"},{ class: "mt-6 ml-2" } %>
         </div>
     </div>
     

--- a/app/views/schedules/_search.html.erb
+++ b/app/views/schedules/_search.html.erb
@@ -1,39 +1,41 @@
-<div class="flex justify-center my-8">
-    <%= search_form_for @q, url: schedules_path do |f| %>
-        <div class="flex justiry-center">
+    <div class="flex justify-center my-8">
+        <%= search_form_for q, url: schedules_path do |f| %>
+        <div class="flex justify-center">
             <%= f.search_field :schedule_title_or_events_event_title_or_events_comment_cont, class: 'form-control input input-bordered input-primary w-full max-w-xs rounded-full m-1', placeholder: '検索ワード' %>
             <%= f.submit '検索', class: 'btn btn-primary rounded-full' %>
         </div>
-        <div class="flex justiry-center">
+
+        <div class="flex justify-center">
             <div class="dropdown">
                 <%= f.label :get_up_time, tabindex: "0", class: "btn btn-outline btn-primary rounded-full m-1"%>
-                    <div tabindex="0" class="dropdown-content menu p-2 shadow bg-primary rounded-box">
-                        <div class="flex">
-                        <%=f.time_select :get_up_time_gteq, {prompt: true, ignore_date: true, minute_step: 15},class: "text-xl"%>
-                        〜
-                        <%=f.time_select :get_up_time_lteq, {prompt: true, ignore_date: true, minute_step: 15},class: "text-xl"%>
-                        </div>
+                <div tabindex="0" class="dropdown-content menu p-2 shadow bg-primary rounded-box">
+                    <div class="flex">
+                    <%=f.time_select :get_up_time_gteq, {prompt: true, ignore_date: true, minute_step: 15},class: "text-xl"%>
+                    〜
+                    <%=f.time_select :get_up_time_lteq, {prompt: true, ignore_date: true, minute_step: 15},class: "text-xl"%>
                     </div>
                 </div>
-                <div class="dropdown">
+            </div>
+
+            <div class="dropdown">
                 <%= f.label :sleep_time, tabindex: "0", class: "btn btn-outline btn-primary rounded-full m-1"%>
-                    <div tabindex="0" class="dropdown-content menu p-2 shadow bg-primary rounded-box">
-                        <div class="flex">
-                        <%=f.time_select :sleep_time_gteq, {prompt: true, ignore_date: true, minute_step: 15},class: "text-xl"%>
-                        〜
-                        <%=f.time_select :sleep_time_lteq, {prompt: true, ignore_date: true, minute_step: 15},class: "text-xl"%>
-                        </div>
+                <div tabindex="0" class="dropdown-content menu p-2 shadow bg-primary rounded-box">
+                    <div class="flex">
+                    <%=f.time_select :sleep_time_gteq, {prompt: true, ignore_date: true, minute_step: 15},class: "text-xl"%>
+                    〜
+                    <%=f.time_select :sleep_time_lteq, {prompt: true, ignore_date: true, minute_step: 15},class: "text-xl"%>
                     </div>
                 </div>
-                <div class="dropdown">
+            </div>
+
+            <div class="dropdown">
                 <%= f.label :assumed_number_people, tabindex: "0", class: "btn btn-outline btn-primary rounded-full m-1"%>
                 <div tabindex="0" class="dropdown-content menu p-2 shadow bg-primary rounded-box rounded-full">
                     <div class="flex">
-                        <%=f.number_field :assumed_number_people_cont%>人
+                        <%=f.select :assumed_number_people_eq, Schedule.assumed_number_people.keys.map.with_index { |k, i| [t("enums.schedule.assumed_number_people.#{k}"), i]}, { include_blank: "人数" }, { class: "text-xl"}%>
                     </div>
                 </div>
             </div>
         </div>
     <% end %>
 </div>
-

--- a/app/views/schedules/_search.html.erb
+++ b/app/views/schedules/_search.html.erb
@@ -10,9 +10,9 @@
                 <%= f.label :get_up_time, tabindex: "0", class: "btn btn-outline btn-primary rounded-full m-1"%>
                 <div tabindex="0" class="dropdown-content menu p-2 shadow bg-primary rounded-box">
                     <div class="flex">
-                    <%=f.time_select :get_up_time_gteq, {prompt: true, ignore_date: true, minute_step: 15},class: "text-xl"%>
-                    〜
-                    <%=f.time_select :get_up_time_lteq, {prompt: true, ignore_date: true, minute_step: 15},class: "text-xl"%>
+                    <%=f.time_select :get_up_time_gteq, {prompt: true, minute_step: 15},class: "text-xl"%>
+                    <span>〜</span>
+                    <%=f.time_select :get_up_time_lteq, {prompt: true, minute_step: 15},class: "text-xl"%>
                     </div>
                 </div>
             </div>
@@ -21,9 +21,9 @@
                 <%= f.label :sleep_time, tabindex: "0", class: "btn btn-outline btn-primary rounded-full m-1"%>
                 <div tabindex="0" class="dropdown-content menu p-2 shadow bg-primary rounded-box">
                     <div class="flex">
-                    <%=f.time_select :sleep_time_gteq, {prompt: true, ignore_date: true, minute_step: 15},class: "text-xl"%>
-                    〜
-                    <%=f.time_select :sleep_time_lteq, {prompt: true, ignore_date: true, minute_step: 15},class: "text-xl"%>
+                    <%=f.time_select :sleep_time_gteq, {prompt: true, minute_step: 15},class: "text-xl"%>
+                    <span>〜</span>
+                    <%=f.time_select :sleep_time_lteq, {prompt: true, minute_step: 15},class: "text-xl"%>
                     </div>
                 </div>
             </div>

--- a/app/views/shared/_schedule_card.html.erb
+++ b/app/views/shared/_schedule_card.html.erb
@@ -56,18 +56,36 @@
             <div class="swiper-button-next"></div>
         </div>
 
+        <div class="flex w-2/3 bg-accent text-white mx-auto p-2 mt-4 text-center">
+            <div class="w-3/12">
+                <h2><%= schedule.get_up_time.strftime( "%H:%M" )%></h2> 
+            </div>
+            <div class="w-9/12 ">
+                <h2>起床時間</h2>  
+            </div>
+        </div>
+
         <% schedule.events.each do |a|%>
             <%= link_to schedule_event_path(@schedule,a) do %>
-                <div class="flex w-2/3 bg-secondary text-white mx-auto p-2 mt-4">
+                <div class="flex w-2/3 bg-secondary text-white mx-auto p-2 mt-4 text-center">
                     <div class="w-3/12">
                         <h2><%= a.start_time.strftime( "%H:%M" )%> ~ <%= a.end_time.strftime( "%H:%M" )%></h2> 
                     </div>
-                    <div class="w-9/12 text-center">
+                    <div class="w-9/12">
                         <h2><%= a.event_title%></h2>  
                     </div>
                 </div>
             <% end %>
         <% end %>
+
+        <div class="flex w-2/3 bg-accent text-white mx-auto p-2 mt-4 text-center">
+            <div class="w-3/12">
+                <h2><%= schedule.sleep_time.strftime( "%H:%M" )%></h2> 
+            </div>
+            <div class="w-9/12">
+                <h2>就寝時間</h2>  
+            </div>
+        </div>
 
     <%= render 'favorites/favorite_btn', schedule: schedule%>
 </div>

--- a/app/views/shared/_schedule_card.html.erb
+++ b/app/views/shared/_schedule_card.html.erb
@@ -30,7 +30,7 @@
                 <h2 class="text-xl">金額 <%= total_price%>円</h2>
             </div>
             <div class="ml-4">
-                <h2 class="text-xl">人数 <%= @schedule.assumed_number_people %>人</h2>
+                <h2 class="text-xl">人数 <%= @schedule.assumed_number_people_i18n %></h2>
             </div>
         </div>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,6 @@ module ScheduleDayOff
     # 言語ファイル階層ごとに設定するための記述
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
     
-    config.time_zone = 'Tokyo'
+   
   end
 end

--- a/config/locales/model/ja.yml
+++ b/config/locales/model/ja.yml
@@ -45,4 +45,10 @@ ja:
       role:
         general: '一般'
         admin: '管理者'
+    schedule:
+      assumed_number_people: 
+          one_person: '一人'
+          two_people: '二人'
+          three_people: '三人'
+          four_or_more_people: '四人以上'
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@ User.all.each do |user|
   5.times {
     Schedule.create!(
       schedule_title: Faker::Hobby.activity,
-      assumed_number_people: Faker::Number.between(from:1, to:5),
+      assumed_number_people: Faker::Number.between(from:1, to:4),
       get_up_time: Faker::Time.between(from: DateTime.now - 1, to: DateTime.now),
       sleep_time: Faker::Time.between(from: DateTime.now - 1, to: DateTime.now),
       user: user,


### PR DESCRIPTION
## 概要

Resolves#51

## 確認方法

1. `bin/dev`でサーバーを起動
2. フリ~ワード、起床時間、就寝時間、人数で検索ができる

## コメント

人数はenumに変更することで検索しやすくした。
起床時間、就寝時間が検索できなかった原因は、Timeオブジェクトが日本時間に変更した際に日付が変わっていることだった。
time_zoneをデフォルトにすることで修正した。今後、日本時間のままで修正できる方法を見つけ次第、修正する。

