### PR TITLE
fix: 追加されたイベントが一番下に追加されるように修正#57

### DIFF
--- a/app/views/schedules/_add_event_fields.html.erb
+++ b/app/views/schedules/_add_event_fields.html.erb
@@ -4,7 +4,7 @@
                             partial: 'events/event_fields',
                             data: {
                                 association_insertion_node: '#under-event-form',
-                                association_insertion_method: 'after'
+                                association_insertion_method: 'append'
                             },
                             form_name: 'kf'
 %>


### PR DESCRIPTION
## 概要

Resolves#57
[![Image from Gyazo](https://i.gyazo.com/37ab9bcfd61ed70014edcfe5858c7ca9.gif)](https://gyazo.com/37ab9bcfd61ed70014edcfe5858c7ca9)

## 確認方法

例
1. `bin/dev`でサーバーを起動
2. 追加ボタンを押すとイベントが一番下に追加される
